### PR TITLE
add conda-forge/aws-sdk-cpp to maintainers

### DIFF
--- a/.ci_support/migrations/aws_c_s30151.yaml
+++ b/.ci_support/migrations/aws_c_s30151.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_c_s3:
-- 0.1.51
-migrator_ts: 1666854319.5473096

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xhochy
+* @conda-forge/aws-sdk-cpp @xhochy

--- a/README.md
+++ b/README.md
@@ -197,5 +197,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@conda-forge/aws-sdk-cpp](https://github.com/conda-forge/aws-sdk-cpp/)
 * [@xhochy](https://github.com/xhochy/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - xhochy
+    - conda-forge/aws-sdk-cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,14 @@ requirements:
     - {{ compiler('cxx') }}
     - ninja
   host:
-    - aws-c-auth
-    - aws-c-cal
+    - aws-checksums
     - aws-c-common
+    - aws-c-cal
+    - aws-c-io
     - aws-c-event-stream
     - aws-c-http
-    - aws-c-io
+    - aws-c-auth
     - aws-c-mqtt
-    - aws-checksums
     - aws-c-s3
 
 test:


### PR DESCRIPTION
centralize maintainership for aws-* stack, as suggested in https://github.com/conda-forge/aws-c-http-feedstock/pull/84